### PR TITLE
adding 'dyn' where appropriate to resolve deprecated

### DIFF
--- a/src/structure/adjacencylist.rs
+++ b/src/structure/adjacencylist.rs
@@ -82,7 +82,7 @@ where F: 'static+FileLoad+FileStore,
         // (which is otherwise an invalid right-hand side) and pushing a 1 onto the bitarray to immediately close the segment.
         let skip = left - self.last_left;
         
-        let f1: Box<Future<Item=(BitArrayFileBuilder<F::Write>, LogArrayFileBuilder<W3>), Error=std::io::Error>> = 
+        let f1: Box<dyn Future<Item=(BitArrayFileBuilder<F::Write>, LogArrayFileBuilder<W3>), Error=std::io::Error>> = 
             if last_left == 0 {
                 // this is the first entry. we can't push a bit yet
                 Box::new(future::ok((bitarray, nums)))

--- a/src/structure/bitarray.rs
+++ b/src/structure/bitarray.rs
@@ -118,7 +118,7 @@ where W: 'static+AsyncWrite {
         }
     }
 
-    fn flush_current(self) -> Box<Future<Item=BitArrayFileBuilder<W>, Error=std::io::Error>> {
+    fn flush_current(self) -> Box<dyn Future<Item=BitArrayFileBuilder<W>, Error=std::io::Error>> {
         let count = self.count;
         Box::new(tokio::io::write_all(self.bit_output, vec![self.current_byte])
                  .map(move |(w,_)| BitArrayFileBuilder {
@@ -129,7 +129,7 @@ where W: 'static+AsyncWrite {
                  }))
     }
 
-    pub fn push(mut self, bit: bool) -> Box<Future<Item=BitArrayFileBuilder<W>, Error=std::io::Error>> {
+    pub fn push(mut self, bit: bool) -> Box<dyn Future<Item=BitArrayFileBuilder<W>, Error=std::io::Error>> {
         let mut b = match bit { true => 128, false => 0 };
         b >>= self.current_bit_pos;
         self.current_byte |= b;
@@ -144,7 +144,7 @@ where W: 'static+AsyncWrite {
         }
     }
 
-    pub fn push_all<S:'static+Stream<Item=bool,Error=std::io::Error>>(self, stream: S) -> Box<Future<Item=BitArrayFileBuilder<W>,Error=std::io::Error>> {
+    pub fn push_all<S:'static+Stream<Item=bool,Error=std::io::Error>>(self, stream: S) -> Box<dyn Future<Item=BitArrayFileBuilder<W>,Error=std::io::Error>> {
         Box::new(stream.fold(self, |builder, bit| builder.push(bit)))
     }
 
@@ -155,7 +155,7 @@ where W: 'static+AsyncWrite {
 
     pub fn finalize(self) -> impl Future<Item=W, Error=std::io::Error> {
         let count = self.count;
-        let flush_current: Box<Future<Item=BitArrayFileBuilder<W>,Error=std::io::Error>> =
+        let flush_current: Box<dyn Future<Item=BitArrayFileBuilder<W>,Error=std::io::Error>> =
             if count % 8 == 0 {
                 Box::new(future::ok(self))
             } else {

--- a/src/structure/bitindex.rs
+++ b/src/structure/bitindex.rs
@@ -139,7 +139,7 @@ impl<'a> BitIndex<'a> {
     }
 }
 
-pub fn build_bitindex<R:'static+AsyncRead,W1:'static+AsyncWrite, W2:'static+AsyncWrite>(bitarray:R, blocks:W1, sblocks:W2) -> Box<Future<Item=(W1, W2),Error=std::io::Error>> {
+pub fn build_bitindex<R:'static+AsyncRead,W1:'static+AsyncWrite, W2:'static+AsyncWrite>(bitarray:R, blocks:W1, sblocks:W2) -> Box<dyn Future<Item=(W1, W2),Error=std::io::Error>> {
     let block_stream = bitarray_stream_blocks(bitarray);
     // the following widths are unoptimized, but should always be large enough
     let blocks_builder = LogArrayFileBuilder::new(blocks, 64-(SBLOCK_SIZE*64).leading_zeros() as u8);

--- a/src/structure/logarray.rs
+++ b/src/structure/logarray.rs
@@ -250,7 +250,7 @@ impl<W:'static+tokio::io::AsyncWrite> LogArrayFileBuilder<W> {
         }
     }
 
-    pub fn push(mut self, val: u64) -> Box<Future<Item=LogArrayFileBuilder<W>,Error=std::io::Error>> {
+    pub fn push(mut self, val: u64) -> Box<dyn Future<Item=LogArrayFileBuilder<W>,Error=std::io::Error>> {
         if val.leading_zeros() < 64 - self.width as u32 {
             panic!("value too large for width");
         }
@@ -302,7 +302,7 @@ impl<W:'static+tokio::io::AsyncWrite> LogArrayFileBuilder<W> {
         } = self;
         
 
-        let write_last_bits: Box<Future<Item=W, Error=std::io::Error>> = if count % 8 == 0 {
+        let write_last_bits: Box<dyn Future<Item=W, Error=std::io::Error>> = if count % 8 == 0 {
             Box::new(future::ok(file))
         }
         else {
@@ -383,7 +383,7 @@ impl Decoder for LogArrayDecoder {
     }
 }
 
-pub fn open_logarray_stream<F:'static+FileLoad>(f: F) -> impl Future<Item=Box<'static+Stream<Item=u64,Error=std::io::Error>>,Error=std::io::Error> {
+pub fn open_logarray_stream<F:'static+FileLoad>(f: F) -> impl Future<Item=Box<dyn 'static+Stream<Item=u64,Error=std::io::Error>>,Error=std::io::Error> {
     let end_offset = f.size() - 8;
     // read the length and width
     tokio::io::read_exact(f.open_read_from(end_offset), vec![0;8])
@@ -391,7 +391,7 @@ pub fn open_logarray_stream<F:'static+FileLoad>(f: F) -> impl Future<Item=Box<'s
             let len = BigEndian::read_u32(&buf);
             let width = buf[4];
 
-            let b: Box<Stream<Item=u64, Error=std::io::Error>> = Box::new(FramedRead::new(f.open_read(), LogArrayDecoder { current: 0, width, offset: 64, remaining: len }));
+            let b: Box<dyn Stream<Item=u64, Error=std::io::Error>> = Box::new(FramedRead::new(f.open_read(), LogArrayDecoder { current: 0, width, offset: 64, remaining: len }));
 
             b
         })

--- a/src/structure/pfc.rs
+++ b/src/structure/pfc.rs
@@ -120,7 +120,7 @@ impl<W:'static+tokio::io::AsyncWrite> PfcDictFileBuilder<W> {
             index: Vec::new()
         }
     }
-    pub fn add(self, s: &str) -> Box<Future<Item=PfcDictFileBuilder<W>,Error=std::io::Error>> {
+    pub fn add(self, s: &str) -> Box<dyn Future<Item=PfcDictFileBuilder<W>,Error=std::io::Error>> {
         let count = self.count;
         let size = self.size;
         let mut index = self.index;
@@ -157,7 +157,7 @@ impl<W:'static+tokio::io::AsyncWrite> PfcDictFileBuilder<W> {
         }
     }
 
-    pub fn add_all<I:'static+Iterator<Item=String>>(self, mut it:I) -> Box<Future<Item=PfcDictFileBuilder<W>, Error=std::io::Error>> {
+    pub fn add_all<I:'static+Iterator<Item=String>>(self, mut it:I) -> Box<dyn Future<Item=PfcDictFileBuilder<W>, Error=std::io::Error>> {
         let next = it.next();
         match next {
             None => Box::new(future::ok(self)),

--- a/src/structure/vbyte.rs
+++ b/src/structure/vbyte.rs
@@ -51,7 +51,7 @@ impl<'a> VByte<'a> {
         dest.write_all(&buf[..trunc_len])
     }
 
-    pub fn write<A>(num: u64, dest: A) -> Box<Future<Item=(A,usize),Error=tokio::io::Error>>
+    pub fn write<A>(num: u64, dest: A) -> Box<dyn Future<Item=(A,usize),Error=tokio::io::Error>>
     where A: 'static+AsyncWrite {
         let mut buf = vec![0;10];
         let trunc_len = {


### PR DESCRIPTION
"trait objects without an explicit `dyn` are deprecated" so added where warnings appeared when checking